### PR TITLE
feat(orders-list-test): add test for correct time formatting

### DIFF
--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -55,4 +55,21 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+
+    test('renders correct time formatting', () => {
+        const orders = [
+            {
+                order_item: "Food",
+                quantity: "777",
+                _id: 1,
+                createdAt: new Date(2022, 11, 24, 15, 4, 3, 0)
+            }
+        ];
+        render(
+            <OrdersList
+                orders={orders}
+            />
+        )
+        expect(screen.getByText(/3:04:03/g)).toBeInTheDocument();
+    });
 })


### PR DESCRIPTION
## Changes
added test for ensuring orders-list times are displayed with "0"-padding and in non-military time.

Closes #3
